### PR TITLE
Net 9 orleans 9

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -14,7 +14,7 @@
 
 # References:
 # - To learn more about .editorconfig see https://aka.ms/editorconfigdocs
-# - Set rule severity https://docs.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2019#set-rule-severity-in-an-editorconfig-file
+# - Set rule severity https://learn.microsoft.com/en-us/visualstudio/code-quality/use-roslyn-analyzers?view=vs-2022#set-rule-severity-in-an-editorconfig-file
 # - Configure analyzer rules https://github.com/dotnet/roslyn-analyzers/blob/main/docs/Analyzer%20Configuration.md
 
 # Note that choices to deviate from the default are governed by these goals:

--- a/.editorconfig
+++ b/.editorconfig
@@ -1,5 +1,5 @@
-﻿# Version 20240405 - C# 12
-# Origin: see https://github.com/Applicita/Modern.CSharp.Templates/blob/main/Editorconfig.md
+﻿# Version 20250331 - C# 13
+# Origin: see https://github.com/VincentH-Net/Modern.CSharp.Templates/blob/main/Editorconfig.md
 
 # This file does not inherit .editorconfig settings from higher directories - where possible, place it at the root of the repository
 
@@ -173,6 +173,11 @@ csharp_using_directive_placement = outside_namespace:warning # Default: outside_
     # Placing usings outside namespaces lets the closest parent namespace control type name match
     # It can also make attribute usage more concise
     # See https://stackoverflow.com/questions/125319/should-using-directives-be-inside-or-outside-the-namespace
+
+# Preferences added with .NET 9 / C# 13
+csharp_prefer_system_threading_lock = true:warning # Default: true:suggestion
+csharp_style_prefer_unbound_generic_type_in_nameof = true:warning # Default: true:suggestion
+csharp_prefer_static_anonymous_function = true:warning # Default: true:suggestion
 
 # New line preferences
 csharp_style_allow_blank_line_after_colon_in_constructor_initializer_experimental = true:silent

--- a/.editorconfig
+++ b/.editorconfig
@@ -49,6 +49,9 @@ tab_width = 2
 indent_size = 4
 tab_width = 4
 
+# See https://github.com/dotnet/roslyn/issues/68413#issuecomment-1943805603
+trim_trailing_whitespace = false
+
 # New line preferences
 insert_final_newline = true # Default: false
 
@@ -319,6 +322,3 @@ dotnet_diagnostic.IDE0072.severity = suggestion
     # while truly unexpected returns should throw an exception. Since switch automatically throws a SwitchExpressionException, 
     # it is valid to not explicitly code cases that throw an exception to indicate the return is truly unexpected.
 dotnet_diagnostic.IDE0130.severity = suggestion # IDE0130 "Namespace does not match folder structure" can be deviated from to prevent overstructuring
-
-# Solution-specific settings
-dotnet_diagnostic.ORLEANS0010.severity = none # adding an alias to every grain contract type and member adds too much noise. This rule should be triggered only during refactoring

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Orleans.Multiservice consists of:
 - An example application that demonstrates the pattern in 2 stages of the application's life cycle:
 
   1) The application starts out as a single microservice, built by a single team, that contains two logical services - one of which depends on the other<br />
-     Source: [Single Team/Microservice eShop](https://github.com/Applicita/Orleans.Multiservice/tree/main/src/Example/eShopBySingleTeam/TeamA)
+     Source: [Single Team/Microservice eShop](https://github.com/InnoWvateDotNet/Orleans.Multiservice/tree/main/src/Example/eShopBySingleTeam/TeamA)
   2) Then a second team is added that will become owner of one of the logical services. A second microservice is added and one logical service is moved into that (in a real world application this could also be moving 5 out of 10 logical services to a second microservice)<br />
-     Source: [Two Team/Microservice eShop](https://github.com/Applicita/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams)
+     Source: [Two Team/Microservice eShop](https://github.com/InnoWvateDotNet/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams)
 
 - A `dotnet new mcs-orleans-multiservice` template to set up a new multiservice, and to add a logical service in an existing multiservice
 
@@ -39,7 +39,7 @@ Orleans.Multiservice consists of:
 > The code analyzer / unit tests will be added in a future release. Note that the multiservice pattern can be used without the analyzer by following the code structure of the template and the [pattern rules](#pattern-rules)
 
 ## Template usage
-1) On the command line, ensure that the [mcs-orleans-multiservice template](https://github.com/Applicita/Modern.CSharp.Templates#readme) is installed:
+1) On the command line, ensure that the [mcs-orleans-multiservice template](https://github.com/InnoWvateDotNet/Modern.CSharp.Templates#readme) is installed:
     ```
     dotnet new install Modern.CSharp.Templates
     ```
@@ -52,7 +52,7 @@ Orleans.Multiservice consists of:
 
 3) To create a new multiservice with one logical service in it, enter e.g.:
     ```
-    dotnet new mcs-orleans-multiservice --RootNamespace Applicita.eShop --Multiservice TeamA --Logicalservice Catalog --allow-scripts Yes
+    dotnet new mcs-orleans-multiservice --RootNamespace InnoWvateDotNet.eShop --Multiservice TeamA --Logicalservice Catalog --allow-scripts Yes
     ```
 
 4) To add a logical service to an existing multiservice solution, type e.g. this command in PowerShell while in the solution folder:
@@ -81,13 +81,13 @@ The only code change needed to move the `CatalogService` to the Team B microserv
 
 ### How to run the example
 Single team solution:
-- Debug [eShopTeamA.sln](https://github.com/Applicita/Orleans.Multiservice/tree/main/src/Example/eShopBySingleTeam/TeamA)
+- Debug [eShopTeamA.sln](https://github.com/InnoWvateDotNet/Orleans.Multiservice/tree/main/src/Example/eShopBySingleTeam/TeamA)
 
 Two team solution:
 - Ensure you have the latest [.NET OpenAPI tool](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/openapi-tools?view=aspnetcore-9.0) for .NET 9 installed:<br />
   `dotnet tool install --global Microsoft.dotnet-openapi`<br />
   On build, this will generate the `CatalogServiceClient` from `CatalogService.json`
-- Debug [eShopTeamAof2.sln](https://github.com/Applicita/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams/TeamA) and [eShopTeamBof2.sln](https://github.com/Applicita/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams/TeamB)
+- Debug [eShopTeamAof2.sln](https://github.com/InnoWvateDotNet/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams/TeamA) and [eShopTeamBof2.sln](https://github.com/InnoWvateDotNet/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams/TeamB)
 
 ### How to test the example
 When testing the API in the generated swagger UI, you can use any integer for `buyerId`.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 ﻿# <img src="img/CSharp-Toolkit-Icon.png" alt="Backend Toolkit" width="64px" />Orleans.Multiservice
-Prevent microservices pain with logical service separation in a modular monolith for [Microsoft Orleans 8](https://learn.microsoft.com/en-us/dotnet/orleans/)
+Prevent microservices pain with logical service separation in a modular monolith for [Microsoft Orleans 9](https://learn.microsoft.com/en-us/dotnet/orleans/)
 
 Orleans.Multiservice is an automated code structuring pattern for logical service separation within a Microsoft Orleans (micro)service.
 
@@ -84,7 +84,7 @@ Single team solution:
 - Debug [eShopTeamA.sln](https://github.com/Applicita/Orleans.Multiservice/tree/main/src/Example/eShopBySingleTeam/TeamA)
 
 Two team solution:
-- Ensure you have the latest [.NET OpenAPI tool](https://learn.microsoft.com/en-us/aspnet/core/web-api/microsoft.dotnet-openapi?view=aspnetcore-8.0) for .NET 8 installed:<br />
+- Ensure you have the latest [.NET OpenAPI tool](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/openapi-tools?view=aspnetcore-9.0) for .NET 9 installed:<br />
   `dotnet tool install --global Microsoft.dotnet-openapi`<br />
   On build, this will generate the `CatalogServiceClient` from `CatalogService.json`
 - Debug [eShopTeamAof2.sln](https://github.com/Applicita/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams/TeamA) and [eShopTeamBof2.sln](https://github.com/Applicita/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams/TeamB)

--- a/README.md
+++ b/README.md
@@ -28,9 +28,9 @@ Orleans.Multiservice consists of:
 - An example application that demonstrates the pattern in 2 stages of the application's life cycle:
 
   1) The application starts out as a single microservice, built by a single team, that contains two logical services - one of which depends on the other<br />
-     Source: [Single Team/Microservice eShop](https://github.com/InnoWvateDotNet/Orleans.Multiservice/tree/main/src/Example/eShopBySingleTeam/TeamA)
+     Source: [Single Team/Microservice eShop](https://github.com/VincentH-Net/Orleans.Multiservice/tree/main/src/Example/eShopBySingleTeam/TeamA)
   2) Then a second team is added that will become owner of one of the logical services. A second microservice is added and one logical service is moved into that (in a real world application this could also be moving 5 out of 10 logical services to a second microservice)<br />
-     Source: [Two Team/Microservice eShop](https://github.com/InnoWvateDotNet/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams)
+     Source: [Two Team/Microservice eShop](https://github.com/VincentH-Net/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams)
 
 - A `dotnet new mcs-orleans-multiservice` template to set up a new multiservice, and to add a logical service in an existing multiservice
 
@@ -39,7 +39,7 @@ Orleans.Multiservice consists of:
 > The code analyzer / unit tests will be added in a future release. Note that the multiservice pattern can be used without the analyzer by following the code structure of the template and the [pattern rules](#pattern-rules)
 
 ## Template usage
-1) On the command line, ensure that the [mcs-orleans-multiservice template](https://github.com/InnoWvateDotNet/Modern.CSharp.Templates#readme) is installed:
+1) On the command line, ensure that the [mcs-orleans-multiservice template](https://github.com/VincentH-Net/Modern.CSharp.Templates#readme) is installed:
     ```
     dotnet new install Modern.CSharp.Templates
     ```
@@ -81,13 +81,13 @@ The only code change needed to move the `CatalogService` to the Team B microserv
 
 ### How to run the example
 Single team solution:
-- Debug [eShopTeamA.sln](https://github.com/InnoWvateDotNet/Orleans.Multiservice/tree/main/src/Example/eShopBySingleTeam/TeamA)
+- Debug [eShopTeamA.sln](https://github.com/VincentH-Net/Orleans.Multiservice/tree/main/src/Example/eShopBySingleTeam/TeamA)
 
 Two team solution:
 - Ensure you have the latest [.NET OpenAPI tool](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/openapi/openapi-tools?view=aspnetcore-9.0) for .NET 9 installed:<br />
   `dotnet tool install --global Microsoft.dotnet-openapi`<br />
   On build, this will generate the `CatalogServiceClient` from `CatalogService.json`
-- Debug [eShopTeamAof2.sln](https://github.com/InnoWvateDotNet/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams/TeamA) and [eShopTeamBof2.sln](https://github.com/InnoWvateDotNet/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams/TeamB)
+- Debug [eShopTeamAof2.sln](https://github.com/VincentH-Net/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams/TeamA) and [eShopTeamBof2.sln](https://github.com/VincentH-Net/Orleans.Multiservice/tree/main/src/Example/eShopByTwoTeams/TeamB)
 
 ### How to test the example
 When testing the API in the generated swagger UI, you can use any integer for `buyerId`.

--- a/src/Example/eShopBySingleTeam/TeamA/AddLogicalService.ps1
+++ b/src/Example/eShopBySingleTeam/TeamA/AddLogicalService.ps1
@@ -6,7 +6,7 @@
 
 # Function to update the Program.cs file to add a new parameter to the RegisterEndpoints method
 function Update-RegisterEndpoints {
-    $newParameter = "`n    typeof(Applicita.eShop.Apis.${Name}Api.${Name}Endpoints)`n"
+    $newParameter = "`n    typeof(InnoWvateDotNet.eShop.Apis.${Name}Api.${Name}Endpoints)`n"
     $apisDirectory = Join-Path -Path $PWD -ChildPath "Apis"
     $programFile = Get-ChildItem -Path $apisDirectory -Recurse -Filter "Program.cs" -ErrorAction SilentlyContinue | Select-Object -First 1
 
@@ -25,6 +25,6 @@ function Update-RegisterEndpoints {
     Write-Warning "Could not automatically add below parameter to the RegisterEndpoints(...) call; please add it manually:$newParameter"
 }
 
-dotnet new mcs-orleans-multiservice --RootNamespace Applicita.eShop -M . --Logicalservice $Name --allow-scripts Yes
+dotnet new mcs-orleans-multiservice --RootNamespace InnoWvateDotNet.eShop -M . --Logicalservice $Name --allow-scripts Yes
 
 Update-RegisterEndpoints

--- a/src/Example/eShopBySingleTeam/TeamA/Apis/Apis.csproj
+++ b/src/Example/eShopBySingleTeam/TeamA/Apis/Apis.csproj
@@ -9,8 +9,8 @@
         <AnalysisLevel>preview-All</AnalysisLevel>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         
-        <AssemblyName>Applicita.eShop.$(MSBuildProjectName).TeamA</AssemblyName>
-        <RootNamespace>Applicita.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+        <AssemblyName>InnoWvateDotNet.eShop.$(MSBuildProjectName).TeamA</AssemblyName>
+        <RootNamespace>InnoWvateDotNet.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Example/eShopBySingleTeam/TeamA/Apis/Apis.csproj
+++ b/src/Example/eShopBySingleTeam/TeamA/Apis/Apis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -19,10 +19,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="9.1.2" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Example/eShopBySingleTeam/TeamA/Apis/BasketApi/BasketsEndpoints.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/Apis/BasketApi/BasketsEndpoints.cs
@@ -1,6 +1,6 @@
-﻿using Applicita.eShop.Contracts.BasketContract;
+﻿using InnoWvateDotNet.eShop.Contracts.BasketContract;
 
-namespace Applicita.eShop.Apis.BasketApi;
+namespace InnoWvateDotNet.eShop.Apis.BasketApi;
 
 public class BasketsEndpoints(IClusterClient orleans) : IEndpoints
 {

--- a/src/Example/eShopBySingleTeam/TeamA/Apis/CatalogApi/CatalogEndpoints.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/Apis/CatalogApi/CatalogEndpoints.cs
@@ -1,6 +1,6 @@
-﻿using Applicita.eShop.Contracts.CatalogContract;
+﻿using InnoWvateDotNet.eShop.Contracts.CatalogContract;
 
-namespace Applicita.eShop.Apis.CatalogApi;
+namespace InnoWvateDotNet.eShop.Apis.CatalogApi;
 
 public class CatalogEndpoints(IClusterClient orleans) : IEndpoints
 {

--- a/src/Example/eShopBySingleTeam/TeamA/Apis/Foundation/Extensions.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/Apis/Foundation/Extensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Applicita.eShop.Apis.Foundation;
+﻿namespace InnoWvateDotNet.eShop.Apis.Foundation;
 
 public interface IEndpoints
 {

--- a/src/Example/eShopBySingleTeam/TeamA/Apis/Foundation/GlobalUsings.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/Apis/Foundation/GlobalUsings.cs
@@ -1,4 +1,4 @@
 ﻿global using System.Collections.Immutable;
 global using Microsoft.AspNetCore.Http.HttpResults;
 global using static Microsoft.AspNetCore.Http.TypedResults;
-global using Applicita.eShop.Apis.Foundation;
+global using InnoWvateDotNet.eShop.Apis.Foundation;

--- a/src/Example/eShopBySingleTeam/TeamA/Apis/Foundation/Program.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/Apis/Foundation/Program.cs
@@ -19,8 +19,8 @@ if (app.Environment.IsDevelopment())
     _ = app.UseSwagger().UseSwaggerUI(options => options.EnableTryItOutByDefault());
 
 app.RegisterEndpoints(
-    typeof(Applicita.eShop.Apis.BasketApi.BasketsEndpoints),
-    typeof(Applicita.eShop.Apis.CatalogApi.CatalogEndpoints)
+    typeof(InnoWvateDotNet.eShop.Apis.BasketApi.BasketsEndpoints),
+    typeof(InnoWvateDotNet.eShop.Apis.CatalogApi.CatalogEndpoints)
 );
 
 app.Run();

--- a/src/Example/eShopBySingleTeam/TeamA/BasketService/BasketGrain.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/BasketService/BasketGrain.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Immutable;
 using System.Globalization;
 
-namespace Applicita.eShop.BasketService;
+namespace InnoWvateDotNet.eShop.BasketService;
 
 sealed class BasketGrain : Grain, IBasketGrain
 {

--- a/src/Example/eShopBySingleTeam/TeamA/BasketService/BasketService.csproj
+++ b/src/Example/eShopBySingleTeam/TeamA/BasketService/BasketService.csproj
@@ -11,8 +11,8 @@
 
     <NoWarn>$(NoWarn);EnableGenerateDocumentationFile</NoWarn>
 
-    <AssemblyName>Applicita.eShop.$(MSBuildProjectName)</AssemblyName>
-    <RootNamespace>Applicita.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <AssemblyName>InnoWvateDotNet.eShop.$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>InnoWvateDotNet.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Example/eShopBySingleTeam/TeamA/BasketService/BasketService.csproj
+++ b/src/Example/eShopBySingleTeam/TeamA/BasketService/BasketService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Runtime" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Runtime" Version="9.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Example/eShopBySingleTeam/TeamA/BasketService/CatalogServiceClientGrain.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/BasketService/CatalogServiceClientGrain.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Immutable;
 using Orleans.Concurrency;
 
-namespace Applicita.eShop.BasketService;
+namespace InnoWvateDotNet.eShop.BasketService;
 
 interface ICatalogServiceClientGrain : IGrainWithIntegerKey
 {

--- a/src/Example/eShopBySingleTeam/TeamA/BasketService/Foundation/GlobalUsings.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/BasketService/Foundation/GlobalUsings.cs
@@ -1,2 +1,2 @@
 ﻿global using Orleans.Runtime;
-global using Applicita.eShop.Contracts.BasketContract;
+global using InnoWvateDotNet.eShop.Contracts.BasketContract;

--- a/src/Example/eShopBySingleTeam/TeamA/CatalogService/CatalogGrain.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/CatalogService/CatalogGrain.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Immutable;
 
-namespace Applicita.eShop.CatalogService;
+namespace InnoWvateDotNet.eShop.CatalogService;
 
 sealed class CatalogGrain([PersistentState("state")] IPersistentState<CatalogGrain.Catalog> catalog) : Grain, ICatalogGrain
 {

--- a/src/Example/eShopBySingleTeam/TeamA/CatalogService/CatalogService.csproj
+++ b/src/Example/eShopBySingleTeam/TeamA/CatalogService/CatalogService.csproj
@@ -11,8 +11,8 @@
 
     <NoWarn>$(NoWarn);EnableGenerateDocumentationFile</NoWarn>
 
-    <AssemblyName>Applicita.eShop.$(MSBuildProjectName)</AssemblyName>
-    <RootNamespace>Applicita.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <AssemblyName>InnoWvateDotNet.eShop.$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>InnoWvateDotNet.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Example/eShopBySingleTeam/TeamA/CatalogService/CatalogService.csproj
+++ b/src/Example/eShopBySingleTeam/TeamA/CatalogService/CatalogService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -16,8 +16,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Runtime" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Runtime" Version="9.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Example/eShopBySingleTeam/TeamA/CatalogService/Foundation/GlobalUsings.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/CatalogService/Foundation/GlobalUsings.cs
@@ -1,2 +1,2 @@
 ﻿global using Orleans.Runtime;
-global using Applicita.eShop.Contracts.CatalogContract;
+global using InnoWvateDotNet.eShop.Contracts.CatalogContract;

--- a/src/Example/eShopBySingleTeam/TeamA/Contracts/BasketContract/BasketContract.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/Contracts/BasketContract/BasketContract.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 
-namespace Applicita.eShop.Contracts.BasketContract;
+namespace InnoWvateDotNet.eShop.Contracts.BasketContract;
 
 public static class GrainFactoryExtensions
 {

--- a/src/Example/eShopBySingleTeam/TeamA/Contracts/CatalogContract/CatalogContract.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/Contracts/CatalogContract/CatalogContract.cs
@@ -1,4 +1,4 @@
-﻿namespace Applicita.eShop.Contracts.CatalogContract;
+﻿namespace InnoWvateDotNet.eShop.Contracts.CatalogContract;
 
 public interface ICatalogGrain : IGrainWithStringKey
 {

--- a/src/Example/eShopBySingleTeam/TeamA/Contracts/CatalogContract/CatalogContract.cs
+++ b/src/Example/eShopBySingleTeam/TeamA/Contracts/CatalogContract/CatalogContract.cs
@@ -2,7 +2,7 @@
 
 public interface ICatalogGrain : IGrainWithStringKey
 {
-    const string Key = "";
+    const string Key = "singleton";
     
     /// <returns>The id of the new product</returns>
     Task<int> CreateProduct(Product product);

--- a/src/Example/eShopBySingleTeam/TeamA/Contracts/Contracts.csproj
+++ b/src/Example/eShopBySingleTeam/TeamA/Contracts/Contracts.csproj
@@ -11,8 +11,8 @@
 
     <NoWarn>$(NoWarn);EnableGenerateDocumentationFile</NoWarn>
 
-    <AssemblyName>Applicita.eShop.$(MSBuildProjectName).TeamA</AssemblyName>
-    <RootNamespace>Applicita.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <AssemblyName>InnoWvateDotNet.eShop.$(MSBuildProjectName).TeamA</AssemblyName>
+    <RootNamespace>InnoWvateDotNet.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Example/eShopBySingleTeam/TeamA/Contracts/Contracts.csproj
+++ b/src/Example/eShopBySingleTeam/TeamA/Contracts/Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -16,7 +16,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Example/eShopBySingleTeam/TeamA/Readme.md
+++ b/src/Example/eShopBySingleTeam/TeamA/Readme.md
@@ -1,7 +1,7 @@
 ﻿# TeamA multiservice
 
 ## The multiservice pattern 
-This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/VincentH-Net/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
+This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/VincentH-Net/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 3.0.0](https://www.nuget.org/packages/Modern.CSharp.Templates/3.0.0) by this command:
 
 `dotnet new mcs-orleans-multiservice --RootNamespace InnoWvateDotNet.eShop --Multiservice TeamA --Logicalservice Catalog`
 

--- a/src/Example/eShopBySingleTeam/TeamA/Readme.md
+++ b/src/Example/eShopBySingleTeam/TeamA/Readme.md
@@ -1,7 +1,7 @@
 ﻿# TeamA multiservice
 
 ## The multiservice pattern 
-This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/InnoWvateDotNet/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
+This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/VincentH-Net/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
 
 `dotnet new mcs-orleans-multiservice --RootNamespace InnoWvateDotNet.eShop --Multiservice TeamA --Logicalservice Catalog`
 
@@ -9,6 +9,6 @@ The `BasketService` was added with this PowerShell command:
 
 `.\AddLogicalService.ps1 Basket`
 
-See the [pattern rules](https://github.com/InnoWvateDotNet/Orleans.Multiservice#pattern-rules) for how to structure code in this solution (this will be guarded by automation in a later template version).
+See the [pattern rules](https://github.com/VincentH-Net/Orleans.Multiservice#pattern-rules) for how to structure code in this solution (this will be guarded by automation in a later template version).
 
 Use [`AddLogicalService.ps1 <name>`](AddLogicalService.ps1) to add more logical services to the solution.

--- a/src/Example/eShopBySingleTeam/TeamA/Readme.md
+++ b/src/Example/eShopBySingleTeam/TeamA/Readme.md
@@ -1,14 +1,14 @@
 ﻿# TeamA multiservice
 
 ## The multiservice pattern 
-This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/Applicita/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
+This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/InnoWvateDotNet/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
 
-`dotnet new mcs-orleans-multiservice --RootNamespace Applicita.eShop --Multiservice TeamA --Logicalservice Catalog`
+`dotnet new mcs-orleans-multiservice --RootNamespace InnoWvateDotNet.eShop --Multiservice TeamA --Logicalservice Catalog`
 
 The `BasketService` was added with this PowerShell command:
 
 `.\AddLogicalService.ps1 Basket`
 
-See the [pattern rules](https://github.com/Applicita/Orleans.Multiservice#pattern-rules) for how to structure code in this solution (this will be guarded by automation in a later template version).
+See the [pattern rules](https://github.com/InnoWvateDotNet/Orleans.Multiservice#pattern-rules) for how to structure code in this solution (this will be guarded by automation in a later template version).
 
 Use [`AddLogicalService.ps1 <name>`](AddLogicalService.ps1) to add more logical services to the solution.

--- a/src/Example/eShopByTwoTeams/TeamA/AddLogicalService.ps1
+++ b/src/Example/eShopByTwoTeams/TeamA/AddLogicalService.ps1
@@ -6,7 +6,7 @@
 
 # Function to update the Program.cs file to add a new parameter to the RegisterEndpoints method
 function Update-RegisterEndpoints {
-    $newParameter = "`n    typeof(Applicita.eShop.Apis.${Name}Api.${Name}Endpoints)`n"
+    $newParameter = "`n    typeof(InnoWvateDotNet.eShop.Apis.${Name}Api.${Name}Endpoints)`n"
     $apisDirectory = Join-Path -Path $PWD -ChildPath "Apis"
     $programFile = Get-ChildItem -Path $apisDirectory -Recurse -Filter "Program.cs" -ErrorAction SilentlyContinue | Select-Object -First 1
 
@@ -25,6 +25,6 @@ function Update-RegisterEndpoints {
     Write-Warning "Could not automatically add below parameter to the RegisterEndpoints(...) call; please add it manually:$newParameter"
 }
 
-dotnet new mcs-orleans-multiservice --RootNamespace Applicita.eShop -M . --Logicalservice $Name --allow-scripts Yes
+dotnet new mcs-orleans-multiservice --RootNamespace InnoWvateDotNet.eShop -M . --Logicalservice $Name --allow-scripts Yes
 
 Update-RegisterEndpoints

--- a/src/Example/eShopByTwoTeams/TeamA/Apis/Apis.csproj
+++ b/src/Example/eShopByTwoTeams/TeamA/Apis/Apis.csproj
@@ -9,8 +9,8 @@
         <AnalysisLevel>preview-All</AnalysisLevel>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         
-        <AssemblyName>Applicita.eShop.$(MSBuildProjectName).TeamA</AssemblyName>
-        <RootNamespace>Applicita.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+        <AssemblyName>InnoWvateDotNet.eShop.$(MSBuildProjectName).TeamA</AssemblyName>
+        <RootNamespace>InnoWvateDotNet.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Example/eShopByTwoTeams/TeamA/Apis/Apis.csproj
+++ b/src/Example/eShopByTwoTeams/TeamA/Apis/Apis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -19,10 +19,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="9.1.2" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Example/eShopByTwoTeams/TeamA/Apis/BasketApi/BasketsEndpoints.cs
+++ b/src/Example/eShopByTwoTeams/TeamA/Apis/BasketApi/BasketsEndpoints.cs
@@ -1,6 +1,6 @@
-﻿using Applicita.eShop.Contracts.BasketContract;
+﻿using InnoWvateDotNet.eShop.Contracts.BasketContract;
 
-namespace Applicita.eShop.Apis.BasketApi;
+namespace InnoWvateDotNet.eShop.Apis.BasketApi;
 
 public class BasketsEndpoints(IClusterClient orleans) : IEndpoints
 {

--- a/src/Example/eShopByTwoTeams/TeamA/Apis/Foundation/Extensions.cs
+++ b/src/Example/eShopByTwoTeams/TeamA/Apis/Foundation/Extensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Applicita.eShop.Apis.Foundation;
+﻿namespace InnoWvateDotNet.eShop.Apis.Foundation;
 
 public interface IEndpoints
 {

--- a/src/Example/eShopByTwoTeams/TeamA/Apis/Foundation/GlobalUsings.cs
+++ b/src/Example/eShopByTwoTeams/TeamA/Apis/Foundation/GlobalUsings.cs
@@ -1,3 +1,3 @@
 ﻿global using Microsoft.AspNetCore.Http.HttpResults;
 global using static Microsoft.AspNetCore.Http.TypedResults;
-global using Applicita.eShop.Apis.Foundation;
+global using InnoWvateDotNet.eShop.Apis.Foundation;

--- a/src/Example/eShopByTwoTeams/TeamA/Apis/Foundation/Program.cs
+++ b/src/Example/eShopByTwoTeams/TeamA/Apis/Foundation/Program.cs
@@ -19,7 +19,7 @@ if (app.Environment.IsDevelopment())
     _ = app.UseSwagger().UseSwaggerUI(options => options.EnableTryItOutByDefault());
 
 app.RegisterEndpoints(
-    typeof(Applicita.eShop.Apis.BasketApi.BasketsEndpoints)
+    typeof(InnoWvateDotNet.eShop.Apis.BasketApi.BasketsEndpoints)
 );
 
 app.Run();

--- a/src/Example/eShopByTwoTeams/TeamA/BasketService/BasketGrain.cs
+++ b/src/Example/eShopByTwoTeams/TeamA/BasketService/BasketGrain.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Immutable;
 using System.Globalization;
 
-namespace Applicita.eShop.BasketService;
+namespace InnoWvateDotNet.eShop.BasketService;
 
 sealed class BasketGrain : Grain, IBasketGrain
 {

--- a/src/Example/eShopByTwoTeams/TeamA/BasketService/BasketService.csproj
+++ b/src/Example/eShopByTwoTeams/TeamA/BasketService/BasketService.csproj
@@ -7,8 +7,8 @@
     <AnalysisLevel>preview-All</AnalysisLevel>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
     <NoWarn>$(NoWarn);EnableGenerateDocumentationFile</NoWarn>
-    <AssemblyName>Applicita.eShop.$(MSBuildProjectName)</AssemblyName>
-    <RootNamespace>Applicita.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <AssemblyName>InnoWvateDotNet.eShop.$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>InnoWvateDotNet.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.Orleans.Runtime" Version="8.0.0" />

--- a/src/Example/eShopByTwoTeams/TeamA/BasketService/BasketService.csproj
+++ b/src/Example/eShopByTwoTeams/TeamA/BasketService/BasketService.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
@@ -11,10 +11,10 @@
     <RootNamespace>InnoWvateDotNet.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Runtime" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Runtime" Version="9.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
     <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
-    <PackageReference Include="NSwag.ApiDescription.Client" Version="14.0.7">
+    <PackageReference Include="NSwag.ApiDescription.Client" Version="14.3.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
@@ -23,6 +23,6 @@
     <ProjectReference Include="..\Contracts\Contracts.csproj" />
   </ItemGroup>
   <ItemGroup>
-    <OpenApiReference Include="CatalogService.json" SourceUrl="http://localhost:5113/swagger/v1/swagger.json" />
+    <OpenApiReference Include="CatalogService.json" SourceUrl="http://localhost:5113/swagger/v1/swagger.json" CodeGenerator="NSwagCSharp" />
   </ItemGroup>
 </Project>

--- a/src/Example/eShopByTwoTeams/TeamA/BasketService/CatalogService.json
+++ b/src/Example/eShopByTwoTeams/TeamA/BasketService/CatalogService.json
@@ -1,11 +1,11 @@
 {
-  "openapi": "3.0.1",
+  "openapi": "3.0.4",
   "info": {
     "title": "Example eShop API by team B of 2",
     "version": "v1"
   },
   "paths": {
-    "/Catalog/products": {
+    "/catalog/products": {
       "post": {
         "tags": [
           "Catalog"
@@ -16,36 +16,15 @@
               "schema": {
                 "$ref": "#/components/schemas/Product"
               }
-            },
-            "text/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Product"
-              }
-            },
-            "application/*+json": {
-              "schema": {
-                "$ref": "#/components/schemas/Product"
-              }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "201": {
             "description": "The new product is created with the returned id",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "integer",
-                  "format": "int32"
-                }
-              },
               "application/json": {
-                "schema": {
-                  "type": "integer",
-                  "format": "int32"
-                }
-              },
-              "text/json": {
                 "schema": {
                   "type": "integer",
                   "format": "int32"
@@ -59,6 +38,7 @@
         "tags": [
           "Catalog"
         ],
+        "operationId": "GetProducts",
         "parameters": [
           {
             "name": "id",
@@ -74,25 +54,9 @@
         ],
         "responses": {
           "200": {
-            "description": "Products for all id's currently in the catalog are returned; unknown product id's are skipped.\r\nIf no id's are specified, all products in the catalog are returned",
+            "description": "Products for all id's currently in the catalog are returned;\r\nunknown product id's are skipped.\r\nIf no id's are specified, all products in the catalog are returned",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Product"
-                  }
-                }
-              },
               "application/json": {
-                "schema": {
-                  "type": "array",
-                  "items": {
-                    "$ref": "#/components/schemas/Product"
-                  }
-                }
-              },
-              "text/json": {
                 "schema": {
                   "type": "array",
                   "items": {
@@ -114,18 +78,9 @@
               "schema": {
                 "$ref": "#/components/schemas/Product"
               }
-            },
-            "text/json": {
-              "schema": {
-                "$ref": "#/components/schemas/Product"
-              }
-            },
-            "application/*+json": {
-              "schema": {
-                "$ref": "#/components/schemas/Product"
-              }
             }
-          }
+          },
+          "required": true
         },
         "responses": {
           "200": {
@@ -134,19 +89,10 @@
           "404": {
             "description": "The product id is not found",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "type": "integer",
+                  "format": "int32"
                 }
               }
             }
@@ -154,7 +100,7 @@
         }
       }
     },
-    "/Catalog/products/{id}": {
+    "/catalog/products/{id}": {
       "delete": {
         "tags": [
           "Catalog"
@@ -177,19 +123,10 @@
           "404": {
             "description": "The product id is not found",
             "content": {
-              "text/plain": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
               "application/json": {
                 "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
-                }
-              },
-              "text/json": {
-                "schema": {
-                  "$ref": "#/components/schemas/ProblemDetails"
+                  "type": "integer",
+                  "format": "int32"
                 }
               }
             }
@@ -200,33 +137,6 @@
   },
   "components": {
     "schemas": {
-      "ProblemDetails": {
-        "type": "object",
-        "properties": {
-          "type": {
-            "type": "string",
-            "nullable": true
-          },
-          "title": {
-            "type": "string",
-            "nullable": true
-          },
-          "status": {
-            "type": "integer",
-            "format": "int32",
-            "nullable": true
-          },
-          "detail": {
-            "type": "string",
-            "nullable": true
-          },
-          "instance": {
-            "type": "string",
-            "nullable": true
-          }
-        },
-        "additionalProperties": { }
-      },
       "Product": {
         "type": "object",
         "properties": {

--- a/src/Example/eShopByTwoTeams/TeamA/BasketService/CatalogServiceClientGrain.cs
+++ b/src/Example/eShopByTwoTeams/TeamA/BasketService/CatalogServiceClientGrain.cs
@@ -17,7 +17,7 @@ sealed class CatalogServiceClientGrain : Grain, ICatalogServiceClientGrain
     public async Task<ImmutableArray<BasketItem>> UpdateFromCurrentProducts(ImmutableArray<BasketItem> basketItems)
     {
         var productIds = basketItems.Select(bi => bi.ProductId).ToImmutableArray();
-        var products = await client.ProductsAllAsync(productIds);
+        var products = await client.GetProductsAsync(productIds);
 
         List<BasketItem> updatedItems = [];
         foreach (var item in basketItems)

--- a/src/Example/eShopByTwoTeams/TeamA/BasketService/CatalogServiceClientGrain.cs
+++ b/src/Example/eShopByTwoTeams/TeamA/BasketService/CatalogServiceClientGrain.cs
@@ -1,7 +1,7 @@
 ﻿using System.Collections.Immutable;
 using Orleans.Concurrency;
 
-namespace Applicita.eShop.BasketService;
+namespace InnoWvateDotNet.eShop.BasketService;
 
 interface ICatalogServiceClientGrain : IGrainWithIntegerKey
 {

--- a/src/Example/eShopByTwoTeams/TeamA/BasketService/Foundation/GlobalUsings.cs
+++ b/src/Example/eShopByTwoTeams/TeamA/BasketService/Foundation/GlobalUsings.cs
@@ -1,2 +1,2 @@
 ﻿global using Orleans.Runtime;
-global using Applicita.eShop.Contracts.BasketContract;
+global using InnoWvateDotNet.eShop.Contracts.BasketContract;

--- a/src/Example/eShopByTwoTeams/TeamA/Contracts/BasketContract/BasketContract.cs
+++ b/src/Example/eShopByTwoTeams/TeamA/Contracts/BasketContract/BasketContract.cs
@@ -1,6 +1,6 @@
 ﻿using System.Globalization;
 
-namespace Applicita.eShop.Contracts.BasketContract;
+namespace InnoWvateDotNet.eShop.Contracts.BasketContract;
 
 public static class GrainFactoryExtensions
 {

--- a/src/Example/eShopByTwoTeams/TeamA/Contracts/Contracts.csproj
+++ b/src/Example/eShopByTwoTeams/TeamA/Contracts/Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,12 +11,12 @@
 
     <NoWarn>$(NoWarn);EnableGenerateDocumentationFile</NoWarn>
 
-    <AssemblyName>Applicita.eShop.$(MSBuildProjectName).TeamA</AssemblyName>
-    <RootNamespace>Applicita.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <AssemblyName>InnoWvateDotNet.eShop.$(MSBuildProjectName).TeamA</AssemblyName>
+    <RootNamespace>InnoWvateDotNet.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Example/eShopByTwoTeams/TeamA/Readme.md
+++ b/src/Example/eShopByTwoTeams/TeamA/Readme.md
@@ -1,7 +1,7 @@
 ﻿# TeamA multiservice
 
 ## The multiservice pattern 
-This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/VincentH-Net/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
+This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/VincentH-Net/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 3.0.0](https://www.nuget.org/packages/Modern.CSharp.Templates/3.0.0) by this command:
 
 `dotnet new mcs-orleans-multiservice --RootNamespace InnoWvateDotNet.eShop --Multiservice TeamA --Logicalservice Catalog`
 

--- a/src/Example/eShopByTwoTeams/TeamA/Readme.md
+++ b/src/Example/eShopByTwoTeams/TeamA/Readme.md
@@ -1,16 +1,16 @@
-# TeamA multiservice
+﻿# TeamA multiservice
 
 ## The multiservice pattern 
-This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/Applicita/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
+This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/VincentH-Net/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
 
-`dotnet new mcs-orleans-multiservice --RootNamespace Applicita.eShop --Multiservice TeamA --Logicalservice Catalog`
+`dotnet new mcs-orleans-multiservice --RootNamespace InnoWvateDotNet.eShop --Multiservice TeamA --Logicalservice Catalog`
 
 The `BasketService` was added with this PowerShell command:
 
 `.\AddLogicalService.ps1 Basket`
 
-After this, the Catalog logical service [was moved to](https://github.com/Applicita/Orleans.Multiservice#proof-by-example-eshop) the TeamB multiservice solution; the Basket service remains in the TeamA solution.
+After this, the Catalog logical service [was moved to](https://github.com/VincentH-Net/Orleans.Multiservice#proof-by-example-eshop) the TeamB multiservice solution; the Basket service remains in the TeamA solution.
 
-See the [pattern rules](https://github.com/Applicita/Orleans.Multiservice#pattern-rules) for how to structure code in this solution (this will be supported by a Roslyn code analyzer in a later template version).
+See the [pattern rules](https://github.com/VincentH-Net/Orleans.Multiservice#pattern-rules) for how to structure code in this solution (this will be supported by a Roslyn code analyzer in a later template version).
 
 Use [`AddLogicalService.ps1 <name>`](AddLogicalService.ps1) to add more logical services to the solution.

--- a/src/Example/eShopByTwoTeams/TeamB/AddLogicalService.ps1
+++ b/src/Example/eShopByTwoTeams/TeamB/AddLogicalService.ps1
@@ -6,7 +6,7 @@
 
 # Function to update the Program.cs file to add a new parameter to the RegisterEndpoints method
 function Update-RegisterEndpoints {
-    $newParameter = "`n    typeof(Applicita.eShop.Apis.${Name}Api.${Name}Endpoints)`n"
+    $newParameter = "`n    typeof(InnoWvateDotNet.eShop.Apis.${Name}Api.${Name}Endpoints)`n"
     $apisDirectory = Join-Path -Path $PWD -ChildPath "Apis"
     $programFile = Get-ChildItem -Path $apisDirectory -Recurse -Filter "Program.cs" -ErrorAction SilentlyContinue | Select-Object -First 1
 
@@ -25,6 +25,6 @@ function Update-RegisterEndpoints {
     Write-Warning "Could not automatically add below parameter to the RegisterEndpoints(...) call; please add it manually:$newParameter"
 }
 
-dotnet new mcs-orleans-multiservice --RootNamespace Applicita.eShop -M . --Logicalservice $Name --allow-scripts Yes
+dotnet new mcs-orleans-multiservice --RootNamespace InnoWvateDotNet.eShop -M . --Logicalservice $Name --allow-scripts Yes
 
 Update-RegisterEndpoints

--- a/src/Example/eShopByTwoTeams/TeamB/Apis/Apis.csproj
+++ b/src/Example/eShopByTwoTeams/TeamB/Apis/Apis.csproj
@@ -9,8 +9,8 @@
         <AnalysisLevel>preview-All</AnalysisLevel>
         <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
         
-        <AssemblyName>Applicita.eShop.$(MSBuildProjectName).TeamA</AssemblyName>
-        <RootNamespace>Applicita.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+        <AssemblyName>InnoWvateDotNet.eShop.$(MSBuildProjectName).TeamA</AssemblyName>
+        <RootNamespace>InnoWvateDotNet.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
     </PropertyGroup>
 
     <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">

--- a/src/Example/eShopByTwoTeams/TeamB/Apis/Apis.csproj
+++ b/src/Example/eShopByTwoTeams/TeamB/Apis/Apis.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
     <PropertyGroup>
-        <TargetFramework>net8.0</TargetFramework>
+        <TargetFramework>net9.0</TargetFramework>
         <Nullable>enable</Nullable>
         <ImplicitUsings>enable</ImplicitUsings>
 
@@ -19,10 +19,10 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="8.0.0" />
-        <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="8.0.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
+        <PackageReference Include="Microsoft.Orleans.Persistence.Memory" Version="9.1.2" />
+        <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
+        <PackageReference Include="Microsoft.AspNetCore.OpenApi" Version="9.0.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="8.0.0" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/Example/eShopByTwoTeams/TeamB/Apis/CatalogApi/CatalogEndpoints.cs
+++ b/src/Example/eShopByTwoTeams/TeamB/Apis/CatalogApi/CatalogEndpoints.cs
@@ -1,6 +1,6 @@
-﻿using Applicita.eShop.Contracts.CatalogContract;
+﻿using InnoWvateDotNet.eShop.Contracts.CatalogContract;
 
-namespace Applicita.eShop.Apis.CatalogApi;
+namespace InnoWvateDotNet.eShop.Apis.CatalogApi;
 
 public class CatalogEndpoints(IClusterClient orleans) : IEndpoints
 {

--- a/src/Example/eShopByTwoTeams/TeamB/Apis/Foundation/Extensions.cs
+++ b/src/Example/eShopByTwoTeams/TeamB/Apis/Foundation/Extensions.cs
@@ -1,4 +1,4 @@
-﻿namespace Applicita.eShop.Apis.Foundation;
+﻿namespace InnoWvateDotNet.eShop.Apis.Foundation;
 
 public interface IEndpoints
 {

--- a/src/Example/eShopByTwoTeams/TeamB/Apis/Foundation/GlobalUsings.cs
+++ b/src/Example/eShopByTwoTeams/TeamB/Apis/Foundation/GlobalUsings.cs
@@ -1,4 +1,4 @@
 ﻿global using System.Collections.Immutable;
 global using Microsoft.AspNetCore.Http.HttpResults;
 global using static Microsoft.AspNetCore.Http.TypedResults;
-global using Applicita.eShop.Apis.Foundation;
+global using InnoWvateDotNet.eShop.Apis.Foundation;

--- a/src/Example/eShopByTwoTeams/TeamB/Apis/Foundation/Program.cs
+++ b/src/Example/eShopByTwoTeams/TeamB/Apis/Foundation/Program.cs
@@ -19,7 +19,7 @@ if (app.Environment.IsDevelopment())
     _ = app.UseSwagger().UseSwaggerUI(options => options.EnableTryItOutByDefault());
 
 app.RegisterEndpoints(
-    typeof(Applicita.eShop.Apis.CatalogApi.CatalogEndpoints)
+    typeof(InnoWvateDotNet.eShop.Apis.CatalogApi.CatalogEndpoints)
 );
 
 app.Run();

--- a/src/Example/eShopByTwoTeams/TeamB/CatalogService/CatalogGrain.cs
+++ b/src/Example/eShopByTwoTeams/TeamB/CatalogService/CatalogGrain.cs
@@ -1,6 +1,6 @@
 ﻿using System.Collections.Immutable;
 
-namespace Applicita.eShop.CatalogService;
+namespace InnoWvateDotNet.eShop.CatalogService;
 
 sealed class CatalogGrain([PersistentState("state")] IPersistentState<CatalogGrain.Catalog> catalog) : Grain, ICatalogGrain
 {

--- a/src/Example/eShopByTwoTeams/TeamB/CatalogService/CatalogService.csproj
+++ b/src/Example/eShopByTwoTeams/TeamB/CatalogService/CatalogService.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,13 +11,13 @@
 
     <NoWarn>$(NoWarn);EnableGenerateDocumentationFile</NoWarn>
 
-    <AssemblyName>Applicita.eShop.$(MSBuildProjectName)</AssemblyName>
-    <RootNamespace>Applicita.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <AssemblyName>InnoWvateDotNet.eShop.$(MSBuildProjectName)</AssemblyName>
+    <RootNamespace>InnoWvateDotNet.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Runtime" Version="8.0.0" />
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Runtime" Version="9.1.2" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Example/eShopByTwoTeams/TeamB/CatalogService/Foundation/GlobalUsings.cs
+++ b/src/Example/eShopByTwoTeams/TeamB/CatalogService/Foundation/GlobalUsings.cs
@@ -1,2 +1,2 @@
 ﻿global using Orleans.Runtime;
-global using Applicita.eShop.Contracts.CatalogContract;
+global using InnoWvateDotNet.eShop.Contracts.CatalogContract;

--- a/src/Example/eShopByTwoTeams/TeamB/Contracts/CatalogContract/CatalogContract.cs
+++ b/src/Example/eShopByTwoTeams/TeamB/Contracts/CatalogContract/CatalogContract.cs
@@ -1,8 +1,8 @@
-﻿namespace Applicita.eShop.Contracts.CatalogContract;
+﻿namespace InnoWvateDotNet.eShop.Contracts.CatalogContract;
 
 public interface ICatalogGrain : IGrainWithStringKey
 {
-    const string Key = "";
+    const string Key = "singleton";
     
     /// <returns>The id of the new product</returns>
     Task<int> CreateProduct(Product product);

--- a/src/Example/eShopByTwoTeams/TeamB/Contracts/Contracts.csproj
+++ b/src/Example/eShopByTwoTeams/TeamB/Contracts/Contracts.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net9.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
 
@@ -11,12 +11,12 @@
     
     <NoWarn>$(NoWarn);EnableGenerateDocumentationFile</NoWarn>
 
-    <AssemblyName>Applicita.eShop.$(MSBuildProjectName).TeamB</AssemblyName>
-    <RootNamespace>Applicita.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
+    <AssemblyName>InnoWvateDotNet.eShop.$(MSBuildProjectName).TeamB</AssemblyName>
+    <RootNamespace>InnoWvateDotNet.eShop.$(MSBuildProjectName.Replace(" ", "_"))</RootNamespace>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Orleans.Sdk" Version="8.0.0" />
+    <PackageReference Include="Microsoft.Orleans.Sdk" Version="9.1.2" />
   </ItemGroup>
 
 </Project>

--- a/src/Example/eShopByTwoTeams/TeamB/Readme.md
+++ b/src/Example/eShopByTwoTeams/TeamB/Readme.md
@@ -1,16 +1,16 @@
-# TeamB multiservice
+﻿# TeamB multiservice
 
 ## The multiservice pattern 
-This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/Applicita/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
+This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/VincentH-Net/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
 
-`dotnet new mcs-orleans-multiservice --RootNamespace Applicita.eShop --Multiservice TeamA --Logicalservice Catalog`
+`dotnet new mcs-orleans-multiservice --RootNamespace InnoWvateDotNet.eShop --Multiservice TeamA --Logicalservice Catalog`
 
 The `BasketService` was added with this PowerShell command:
 
 `.\AddLogicalService.ps1 Basket`
 
-After this, the Catalog logical service [was moved to](https://github.com/Applicita/Orleans.Multiservice#proof-by-example-eshop) the TeamB multiservice solution; the Basket service remains in the TeamA solution.
+After this, the Catalog logical service [was moved to](https://github.com/VincentH-Net/Orleans.Multiservice#proof-by-example-eshop) the TeamB multiservice solution; the Basket service remains in the TeamA solution.
 
-See the [pattern rules](https://github.com/Applicita/Orleans.Multiservice#pattern-rules) for how to structure code in this solution (this will be supported by a Roslyn code analyzer in a later template version).
+See the [pattern rules](https://github.com/VincentH-Net/Orleans.Multiservice#pattern-rules) for how to structure code in this solution (this will be supported by a Roslyn code analyzer in a later template version).
 
 Use [`AddLogicalService.ps1 <name>`](AddLogicalService.ps1) to add more logical services to the solution.

--- a/src/Example/eShopByTwoTeams/TeamB/Readme.md
+++ b/src/Example/eShopByTwoTeams/TeamB/Readme.md
@@ -1,7 +1,7 @@
 ﻿# TeamB multiservice
 
 ## The multiservice pattern 
-This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/VincentH-Net/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 1.1.0](https://www.nuget.org/packages/Modern.CSharp.Templates/1.1.0) by this command:
+This solution follows the [Multiservice pattern for Microsoft Orleans](https://github.com/VincentH-Net/Orleans.Multiservice#readme); it was generated with [Modern.CSharp.Templates 3.0.0](https://www.nuget.org/packages/Modern.CSharp.Templates/3.0.0) by this command:
 
 `dotnet new mcs-orleans-multiservice --RootNamespace InnoWvateDotNet.eShop --Multiservice TeamA --Logicalservice Catalog`
 


### PR DESCRIPTION
- Update to C# 13, .NET 9 and Orleans 9
- Fix for Orleans 9 breaking change: empty / whitespace grain string keys are no longer allowed - see dotnet/orleans#9175 and dotnet/orleans#9111
- Replace Applicita references with InnoWvate.NET to reflect repo transfer
- Update links in readme's to upcoming Modern.CSharp.Templates release 3.0